### PR TITLE
satsub 0, -0x80000000 が -0x80000000になる

### DIFF
--- a/src/cpu/cpu_common/cpu_ops.h
+++ b/src/cpu/cpu_common/cpu_ops.h
@@ -208,7 +208,7 @@ static inline sint32 op_ori(
 
 static inline sint32 op_satadd(
 		CpuRegisterType *cpu,
-		sint32 data_l, sint32 data_r)
+		sint32 data_l, sint64 data_r)
 {
 	sint32 ret;
 	sint64 data_r64 = data_r;

--- a/src/cpu/cpu_exec/op_exec_sat.c
+++ b/src/cpu/cpu_exec/op_exec_sat.c
@@ -77,7 +77,7 @@ int op_exec_satsub_1(TargetCoreType *cpu)
 	if (reg2 >= CPU_GREG_NUM) {
 		return -1;
 	}
-	result = op_satadd(&cpu->reg, cpu->reg.r[reg2], -((sint32)cpu->reg.r[reg1]));
+	result = op_satadd(&cpu->reg, cpu->reg.r[reg2], -((sint64)cpu->reg.r[reg1]));
 	DBG_PRINT((DBG_EXEC_OP_BUF(), DBG_EXEC_OP_BUF_LEN(), "0x%x: SATSUB r%d(%d),r%d(%d):%d\n", cpu->reg.pc, reg1, cpu->reg.r[reg1], reg2, cpu->reg.r[reg2], result));
 
 	cpu->reg.r[reg2] = result;
@@ -97,7 +97,7 @@ int op_exec_satsubr_1(TargetCoreType *cpu)
 	if (reg2 >= CPU_GREG_NUM) {
 		return -1;
 	}
-	result = op_satadd(&cpu->reg, cpu->reg.r[reg1], -((sint32)cpu->reg.r[reg2]));
+	result = op_satadd(&cpu->reg, cpu->reg.r[reg1], -((sint64)cpu->reg.r[reg2]));
 	DBG_PRINT((DBG_EXEC_OP_BUF(), DBG_EXEC_OP_BUF_LEN(), "0x%x: SATSUBR r%d(%d),r%d(%d):%d\n",
 			cpu->reg.pc,
 			reg1, cpu->reg.r[reg1],
@@ -208,7 +208,7 @@ int op_exec_satsub_11(TargetCoreType *cpu)
 	if (reg3 >= CPU_GREG_NUM) {
 		return -1;
 	}
-	result = op_satadd(&cpu->reg, cpu->reg.r[reg2], -((sint32)cpu->reg.r[reg1]));
+	result = op_satadd(&cpu->reg, cpu->reg.r[reg2], -((sint64)cpu->reg.r[reg1]));
 	DBG_PRINT((DBG_EXEC_OP_BUF(), DBG_EXEC_OP_BUF_LEN(), "0x%x: SATSUB r%d(%d),r%d(%d), r%d(%d):%d\n",
 			cpu->reg.pc,
 			reg1, cpu->reg.r[reg1],


### PR DESCRIPTION
-(-0x80000000)は0x80000000となりますが、sint32で表現できないため、-0x80000000となります。
op_sataddのdata_rの型をsint32からsint64に変更しました。