### PR TITLE
treat MULHI reg1 as a signed halfword

### DIFF
--- a/src/cpu/cpu_exec/op_exec_arithm.c
+++ b/src/cpu/cpu_exec/op_exec_arithm.c
@@ -600,7 +600,7 @@ int op_exec_mulhi(TargetCoreType *cpu)
 	if (reg2 >= CPU_GREG_NUM) {
 		return -1;
 	}
-	result = op_mulhi(&cpu->reg, imm_data, cpu->reg.r[reg1]);
+	result = op_mulhi(&cpu->reg, imm_data, (sint32)((sint16)cpu->reg.r[reg1]));
 	DBG_PRINT((DBG_EXEC_OP_BUF(), DBG_EXEC_OP_BUF_LEN(), "0x%x: MULHI imm16(%d),r%d(%d) r%d(%d):%d\n", cpu->reg.pc, imm_data, reg1, cpu->reg.r[reg1], reg2, cpu->reg.r[reg2], result));
 
 	cpu->reg.r[reg2] = result;


### PR DESCRIPTION
MULHI's reg1 is a signed halfword, but it is calculated as a signed word.