### PR TITLE
implement trncf.sul and floorf.sul

### DIFF
--- a/src/cpu/cpu_exec/op_exec.h
+++ b/src/cpu/cpu_exec/op_exec.h
@@ -224,7 +224,7 @@ extern OpExecType op_exec_table[OP_EXEC_TABLE_NUM];
 #define op_exec_cvtf_ws_F	op_exec_cvtf_ws_F
 #define op_exec_divf_s_F	op_exec_divf_s_F
 #define op_exec_floorf_sl_F	NULL /* not supported */
-#define op_exec_floorf_sul_F	NULL /* not supported */
+#define op_exec_floorf_sul_F	op_exec_floorf_sul_F
 #define op_exec_floorf_suw_F	NULL /* not supported */
 #define op_exec_floorf_sw_F	NULL /* not supported */
 #define op_exec_fmaf_s_F	op_exec_fmaf_s_F
@@ -245,7 +245,7 @@ extern OpExecType op_exec_table[OP_EXEC_TABLE_NUM];
 #define op_exec_subf_s_F	op_exec_subf_s_F
 #define op_exec_trfsr_F		op_exec_trfsr_F
 #define op_exec_trncf_sl_F	NULL /* not supported */
-#define op_exec_trncf_sul_F	NULL /* not supported */
+#define op_exec_trncf_sul_F	op_exec_trncf_sul_F
 #define op_exec_trncf_suw_F	op_exec_trncf_suw_F
 #define op_exec_trncf_sw_F	op_exec_trncf_sw_F
 

--- a/src/cpu/cpu_exec/op_exec_fpu.c
+++ b/src/cpu/cpu_exec/op_exec_fpu.c
@@ -3180,8 +3180,8 @@ int op_exec_trncf_sul_F(TargetCoreType *cpu)
 	DBG_PRINT((DBG_EXEC_OP_BUF(), DBG_EXEC_OP_BUF_LEN(), "0x%x: TRNCF.SUL r%d(%f) r%d :%llu\n",
         cpu->reg.pc, reg2, reg2_data.data, reg3_0,result_data));
 //	printf( "0x%x: TRNCF.SUL r%d(%f) r%d :%llu\n", cpu->reg.pc, reg2, reg2_data.data, reg3_0,result_data);
-	cpu->reg.r[reg3_0] = (uint32)(result_data>>32);
-	cpu->reg.r[reg3_1] = (uint32)(result_data & 0xffffffff);
+	cpu->reg.r[reg3_0] = (uint32)(result_data & 0xffffffff);
+	cpu->reg.r[reg3_1] = (uint32)(result_data>>32);
 	cpu->reg.pc += 4;
 
 	return 0;
@@ -3311,8 +3311,8 @@ int op_exec_floorf_sul_F(TargetCoreType *cpu)
 
 	//DBG_PRINT((DBG_EXEC_OP_BUF(), DBG_EXEC_OP_BUF_LEN(), "0x%x: FLOORF.SUL r%d(%f) r%d :%llu\n", cpu->reg.pc, reg2, reg2_data.data, reg3_0,result_data));
   //printf( "0x%x: FLOORF.SUL r%d(%f) r%d :%llu\n", cpu->reg.pc, reg2, reg2_data.data, reg3_0,result_data);
-	cpu->reg.r[reg3_0] = (uint32)(result_data>>32);
-	cpu->reg.r[reg3_1] = (uint32)(result_data & 0xffffffff);
+	cpu->reg.r[reg3_0] = (uint32)(result_data & 0xffffffff);
+	cpu->reg.r[reg3_1] = (uint32)(result_data>>32);
 	printf( "0x%x: FLOORF.SUL r%d(%f) r%d :%llu\n", cpu->reg.pc, reg2, reg2_data.data, reg3_0,result_data);
 
 	cpu->reg.pc += 4;


### PR DESCRIPTION
Since op_exec_trncf_sul_F and op_exec_floorf_sul_F are implemented, ensure that the corresponding entries in op_exec_table are not NULL. Fix the issue where the upper 32 bits and lower 32 bits of the results of op_exec_trncf_sul_F and op_exec_floorf_sul_F are reversed.