### PR TITLE
-fwrapv option has been added to prevent signed integer overflow from resulting in undefined behavior

### DIFF
--- a/build_linux/Makefile.env
+++ b/build_linux/Makefile.env
@@ -129,4 +129,4 @@ endif
 .SUFFIXES:      .c .o
 
 .c.o:	$<
-	$(GCC) -O3 -c $(CFLAGS) $(DFLAGS) $<
+	$(GCC) -O3 -fwrapv -c $(CFLAGS) $(DFLAGS) $<


### PR DESCRIPTION
In op_exec_sbf_11 of athrill-target-rh850f1x/src/cpu/cpu_exec/op_exec_arithm.c,
under the conditions where
``` 
reg_data1 = 0x80000000
reg_data2 = 0
add_data = 0
result = 0x80000000
```
the PSW_S bit should be set by `op_chk_and_set_sign`, but it was not set. 

In the calculation of `result`

https://github.com/toppers/athrill-target-rh850f1x/blob/ce173e0027a08b5474b5ae31d49b08333be9f3bb/src/cpu/cpu_exec/op_exec_arithm.c#L1396

a signed integer overflow occurs, resulting in undefined behavior, which is why the PSW_S bit was not set. 
By adding the -fwrapv option, the PSW_S bit is now correctly set.