### PR TITLE
Revert unsupported floating-point operation enablement

### DIFF
--- a/src/cpu/cpu_exec/op_exec.h
+++ b/src/cpu/cpu_exec/op_exec.h
@@ -223,10 +223,10 @@ extern OpExecType op_exec_table[OP_EXEC_TABLE_NUM];
 #define op_exec_cvtf_uws_F	op_exec_cvtf_uws_F
 #define op_exec_cvtf_ws_F	op_exec_cvtf_ws_F
 #define op_exec_divf_s_F	op_exec_divf_s_F
-#define op_exec_floorf_sl_F	op_exec_floorf_sl_F
+#define op_exec_floorf_sl_F	NULL /* not supported */
 #define op_exec_floorf_sul_F	op_exec_floorf_sul_F
-#define op_exec_floorf_suw_F	op_exec_floorf_suw_F
-#define op_exec_floorf_sw_F	op_exec_floorf_sw_F
+#define op_exec_floorf_suw_F	NULL /* not supported */
+#define op_exec_floorf_sw_F	NULL /* not supported */
 #define op_exec_fmaf_s_F	op_exec_fmaf_s_F
 #define op_exec_fmsf_s_F	op_exec_fmsf_s_F
 #define op_exec_fnmaf_s_F	op_exec_fnmaf_s_F
@@ -235,16 +235,16 @@ extern OpExecType op_exec_table[OP_EXEC_TABLE_NUM];
 #define op_exec_minf_s_F	op_exec_minf_s_F
 #define op_exec_mulf_s_F	op_exec_mulf_s_F
 #define op_exec_negf_s_F	op_exec_negf_s_F
-#define op_exec_recipf_s_F	op_exec_recipf_s_F
+#define op_exec_recipf_s_F	NULL /* not supported */
 #define op_exec_roundf_sl_F	NULL /* not supported */
 #define op_exec_roundf_sul_F	NULL /* not supported */
 #define op_exec_roundf_suw_F	NULL /* not supported */
 #define op_exec_roundf_sw_F	NULL /* not supported */
-#define op_exec_rsqrtf_s_F	op_exec_rsqrtf_s_F
-#define op_exec_sqrtf_s_F	op_exec_sqrtf_s_F
+#define op_exec_rsqrtf_s_F	NULL /* not supported */
+#define op_exec_sqrtf_s_F	NULL /* not supported */
 #define op_exec_subf_s_F	op_exec_subf_s_F
 #define op_exec_trfsr_F		op_exec_trfsr_F
-#define op_exec_trncf_sl_F	op_exec_trncf_sl_F
+#define op_exec_trncf_sl_F	NULL /* not supported */
 #define op_exec_trncf_sul_F	op_exec_trncf_sul_F
 #define op_exec_trncf_suw_F	op_exec_trncf_suw_F
 #define op_exec_trncf_sw_F	op_exec_trncf_sw_F


### PR DESCRIPTION
## Summary
- restore the op_exec macros for unsupported floating-point instructions to NULL handlers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d67143cba0832297d71e8a73f1b359